### PR TITLE
Bugfix: Clear evidence storage after search

### DIFF
--- a/src/search/mcm_search/annealing.cpp
+++ b/src/search/mcm_search/annealing.cpp
@@ -169,6 +169,9 @@ MCM MCMSearch::simulated_annealing(Data& data, MCM* init_mcm, std::string file_n
         *this->output_file << "\n";
         this->output_file.reset();
     }
+    
+    // Clear the storage of log-evidences
+    this->evidence_storage.clear();
 
     return this->mcm_out;
 }

--- a/src/search/mcm_search/div_and_conq.cpp
+++ b/src/search/mcm_search/div_and_conq.cpp
@@ -92,6 +92,9 @@ MCM MCMSearch::divide_and_conquer(Data& data, MCM* init_mcm, std::string file_na
         this->output_file.reset();
     }
 
+    // Clear the storage of log-evidences
+    this->evidence_storage.clear();
+
     return this->mcm_out;
 }
 

--- a/src/search/mcm_search/greedy.cpp
+++ b/src/search/mcm_search/greedy.cpp
@@ -85,6 +85,9 @@ MCM MCMSearch::greedy_search(Data& data, MCM* init_mcm, std::string file_name){
         this->output_file.reset();
     }
 
+    // Clear the storage of log-evidences
+    this->evidence_storage.clear();
+
     return this->mcm_out;
 }
 


### PR DESCRIPTION
This MR aims at fixing the following bug:

Running a hierarchical greedy or simulated annealing algorithm to find the best MCM for a given dataset after running it for another dataset with the same MCMSearch object yields incorrect results.

The problem was that the evidence storage that keeps track of the log-evidence for ICCs that have already been calculated during the search was not cleared after the search. When running a search for a second dataset the log-evidence for certain ICCs was not recalculated because they were still stored from the last search.

This issue is fixed by clearing the storage after each search.

